### PR TITLE
fix: 메인메뉴 마우스 이벤트 ul로 변경

### DIFF
--- a/fe/public/index.html
+++ b/fe/public/index.html
@@ -7,6 +7,10 @@
       name="description"
       content="Side Dish - 반찬을 판매하는 쇼핑 서비스입니다."
     />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@500&family=Outfit:wght@500&display=swap"
+      rel="stylesheet"
+    />
     <title>Side Dish</title>
   </head>
   <body>

--- a/fe/src/App.jsx
+++ b/fe/src/App.jsx
@@ -8,11 +8,6 @@ const App = () => {
     <div className="App">
       <Reset />
       <Normalize />
-      {/* TODO: 링크 연결 하드코딩인것 문제 랑.. 해결 */}
-      <link
-        href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@500&family=Outfit:wght@500&display=swap"
-        rel="stylesheet"
-      />
       <Header />
       <Main />
     </div>

--- a/fe/src/Component/Header/HeaderLeft/HeaderLeft.jsx
+++ b/fe/src/Component/Header/HeaderLeft/HeaderLeft.jsx
@@ -7,6 +7,7 @@ const HeaderLeft = ({ state: { handleMouseEvent, checkIsOpen } }) => {
     <NavArea>
       <h1>Ordering</h1>
       <Nav state={{ handleMouseEvent, checkIsOpen }} />
+      {/* TODO: submenu를 이 위치로 옮기기 */}
     </NavArea>
   );
 };

--- a/fe/src/Component/Header/HeaderLeft/Menu.Styled.js
+++ b/fe/src/Component/Header/HeaderLeft/Menu.Styled.js
@@ -1,5 +1,14 @@
 import styled from "styled-components";
 
+const MainMenuUl = styled.ul`
+  display: flex;
+  cursor: pointer;
+
+  li:not(:last-child) {
+    margin-right: 24px;
+  }
+`;
+
 const SubMenuUl = styled.ul`
   font-family: "Noto Sans KR";
   font-size: 14px;
@@ -13,4 +22,4 @@ const SubMenuUl = styled.ul`
   }
 `;
 
-export default SubMenuUl;
+export { MainMenuUl, SubMenuUl };

--- a/fe/src/Component/Header/HeaderLeft/Menu.jsx
+++ b/fe/src/Component/Header/HeaderLeft/Menu.jsx
@@ -1,6 +1,6 @@
 import PropTypes from "prop-types";
 import { MenuDatas } from "../../../MockData/MockData";
-import SubMenuUl from "./Menu.Styled";
+import { MainMenuUl, SubMenuUl } from "./Menu.Styled";
 
 const SubMenu = ({ subMenuDatas }) => {
   const subMenuList = subMenuDatas.map((subMenuData) => (
@@ -15,16 +15,22 @@ const Menu = ({ state: { handleMouseEvent, checkIsOpen } }) => {
     return checkIsOpen() ? <SubMenu subMenuDatas={subMenu} /> : null;
   };
 
-  return MenuDatas.map(({ id, name, subMenu }) => (
-    <li
-      key={id}
-      onMouseEnter={handleMouseEvent}
-      onMouseLeave={handleMouseEvent}
-    >
+  const MainMenu = MenuDatas.map(({ id, name, subMenu }) => (
+    <li key={id}>
       {name}
       {subMenuContents(subMenu)}
     </li>
   ));
+
+  return (
+    <MainMenuUl onMouseEnter={handleMouseEvent} onMouseLeave={handleMouseEvent}>
+      {MainMenu}
+    </MainMenuUl>
+  );
+};
+
+Menu.propTypes = {
+  state: PropTypes.objectOf(PropTypes.func).isRequired,
 };
 
 SubMenu.propTypes = {

--- a/fe/src/Component/Header/HeaderLeft/Nav.jsx
+++ b/fe/src/Component/Header/HeaderLeft/Nav.jsx
@@ -1,13 +1,11 @@
 import PropTypes from "prop-types";
 import Menu from "./Menu";
-import { StyledNav, StyledUl } from "./Nav.styled";
+import StyledNav from "./Nav.styled";
 
 const Nav = ({ state: { handleMouseEvent, checkIsOpen } }) => {
   return (
     <StyledNav>
-      <StyledUl>
-        <Menu state={{ handleMouseEvent, checkIsOpen }} />
-      </StyledUl>
+      <Menu state={{ handleMouseEvent, checkIsOpen }} />
     </StyledNav>
   );
 };

--- a/fe/src/Component/Header/HeaderLeft/Nav.styled.js
+++ b/fe/src/Component/Header/HeaderLeft/Nav.styled.js
@@ -1,17 +1,5 @@
 import styled from "styled-components";
 
-const StyledUl = styled.ul`
-  display: flex;
-
-  li {
-    cursor: pointer;
-
-    &:not(:last-child) {
-      margin-right: 24px;
-    }
-  }
-`;
-
 const StyledNav = styled.nav`
   font-family: "Noto Sans KR";
   font-weight: 400;
@@ -21,4 +9,4 @@ const StyledNav = styled.nav`
   margin-left: 40px;
 `;
 
-export { StyledUl, StyledNav };
+export default StyledNav;


### PR DESCRIPTION
- 폰트 적용 부분을 index.html로 이동
  ```
  Please do not use @import CSS syntax in createGlobalStyle at this time, as the CSSOM APIs we use in production do not handle it well. Instead, we recommend using a library such as react-helmet to inject a typical <link> meta tag to the stylesheet, or simply embedding it manually in your index.html <head> section for a simpler app
  ```
  - 위 warning 메시지가 `GlobalStyle`에서 웹폰트 적용시 표시되는데, 기존처럼 App.jsx안에서 <link>태그로 추가시 컴포넌트 구조가 아님에도 컴포넌트위치에 들어가기 때문에 위 제안대로 index.html로 옮겼습니다!
  - react-helmet을 이용(https://choi95.tistory.com/169)하는 방법도 있었으나, 다른 패키지나 라이브러리를 사용하기 보다 간단한 방법으로 적용했습니다.
  
- 메인메뉴 마우스 이벤트를 li에서 ul로 변경
  - 기존처럼 li로 할 시에는 메인메뉴 사이여백 이동시 노출되었던 레이어가 사라지므로 변경