### PR TITLE
refactor: Menu 컴포넌트 리팩토링

### DIFF
--- a/fe/src/Component/Header/HeaderLeft/Menu.jsx
+++ b/fe/src/Component/Header/HeaderLeft/Menu.jsx
@@ -10,9 +10,9 @@ const SubMenu = ({ subMenuDatas }) => {
   return <SubMenuUl>{subMenuList}</SubMenuUl>;
 };
 
-const Menu = ({ state: { handleMouseEvent, checkIsOpen } }) => {
+const Menu = ({ isOpen }) => {
   const subMenuContents = (subMenu) => {
-    return checkIsOpen() ? <SubMenu subMenuDatas={subMenu} /> : null;
+    return isOpen() ? <SubMenu subMenuDatas={subMenu} /> : null;
   };
 
   const MainMenu = MenuDatas.map(({ id, name, subMenu }) => (
@@ -22,15 +22,11 @@ const Menu = ({ state: { handleMouseEvent, checkIsOpen } }) => {
     </li>
   ));
 
-  return (
-    <MainMenuUl onMouseEnter={handleMouseEvent} onMouseLeave={handleMouseEvent}>
-      {MainMenu}
-    </MainMenuUl>
-  );
+  return <MainMenuUl>{MainMenu}</MainMenuUl>;
 };
 
 Menu.propTypes = {
-  state: PropTypes.objectOf(PropTypes.func).isRequired,
+  isOpen: PropTypes.func.isRequired,
 };
 
 SubMenu.propTypes = {

--- a/fe/src/Component/Header/HeaderLeft/Menu.jsx
+++ b/fe/src/Component/Header/HeaderLeft/Menu.jsx
@@ -11,18 +11,14 @@ const SubMenu = ({ subMenuDatas }) => {
 };
 
 const Menu = ({ isOpen }) => {
-  const subMenuContents = (subMenu) => {
-    return isOpen() ? <SubMenu subMenuDatas={subMenu} /> : null;
-  };
-
-  const MainMenu = MenuDatas.map(({ id, name, subMenu }) => (
+  const MainMenuList = MenuDatas.map(({ id, name, subMenu }) => (
     <li key={id}>
       {name}
-      {subMenuContents(subMenu)}
+      {isOpen && <SubMenu subMenuDatas={subMenu} />}
     </li>
   ));
 
-  return <MainMenuUl>{MainMenu}</MainMenuUl>;
+  return <MainMenuUl>{MainMenuList}</MainMenuUl>;
 };
 
 Menu.propTypes = {

--- a/fe/src/Component/Header/HeaderLeft/Nav.jsx
+++ b/fe/src/Component/Header/HeaderLeft/Nav.jsx
@@ -5,7 +5,7 @@ import StyledNav from "./Nav.styled";
 const Nav = ({ state: { handleMouseEvent, checkIsOpen } }) => {
   return (
     <StyledNav onMouseEnter={handleMouseEvent} onMouseLeave={handleMouseEvent}>
-      <Menu isOpen={checkIsOpen} />
+      <Menu isOpen={checkIsOpen()} />
     </StyledNav>
   );
 };

--- a/fe/src/Component/Header/HeaderLeft/Nav.jsx
+++ b/fe/src/Component/Header/HeaderLeft/Nav.jsx
@@ -4,8 +4,8 @@ import StyledNav from "./Nav.styled";
 
 const Nav = ({ state: { handleMouseEvent, checkIsOpen } }) => {
   return (
-    <StyledNav>
-      <Menu state={{ handleMouseEvent, checkIsOpen }} />
+    <StyledNav onMouseEnter={handleMouseEvent} onMouseLeave={handleMouseEvent}>
+      <Menu isOpen={checkIsOpen} />
     </StyledNav>
   );
 };


### PR DESCRIPTION
- 메뉴컴포넌트 리팩토링

전
```js
const Menu = ({ state: { handleMouseEvent, checkIsOpen } }) => {
  const subMenuContents = (subMenu) => {
    return checkIsOpen() ? <SubMenu subMenuDatas={subMenu} /> : null;
  };

  const MainMenu = MenuDatas.map(({ id, name, subMenu }) => (
    <li key={id}>
      {name}
      {subMenuContents(subMenu)}
    </li>
  ));
```

후
```js
const Menu = ({ isOpen }) => {
  const MainMenuList = MenuDatas.map(({ id, name, subMenu }) => (
    <li key={id}>
      {name}
      {isOpen && <SubMenu subMenuDatas={subMenu} />}
    </li>
  ));
```

- 메뉴 컴포넌트로 넘겨주어 사용했던 이벤트들을 `Nav` 컴포넌트에서 바로 사용하도록 변경

위 사항에 대해서 리팩토링 진행했습니다!
