### PR TITLE
refactor: Header영역 props관련 리팩토링

### DIFF
--- a/fe/src/Component/Header/Header.jsx
+++ b/fe/src/Component/Header/Header.jsx
@@ -12,17 +12,14 @@ const maxSubMenuDataSize = MenuDatas.reduce((maxLength, curMenuData) => {
 const Header = () => {
   const [isOpen, setIsOpen] = useState(false);
 
-  const checkIsOpen = () => {
-    return isOpen;
-  };
-
+  const isSubMenuOpen = isOpen;
   const handleMouseEvent = () => {
     setIsOpen(!isOpen);
   };
 
   return (
     <StyledHeader isOpen={isOpen} maxSubMenuDataSize={maxSubMenuDataSize}>
-      <HeaderLeft state={{ handleMouseEvent, checkIsOpen }} />
+      <HeaderLeft state={{ handleMouseEvent, isSubMenuOpen }} />
       <HeaderRight />
     </StyledHeader>
   );

--- a/fe/src/Component/Header/HeaderLeft/HeaderLeft.jsx
+++ b/fe/src/Component/Header/HeaderLeft/HeaderLeft.jsx
@@ -2,18 +2,19 @@ import PropTypes from "prop-types";
 import Nav from "./Nav";
 import NavArea from "./HeaderLeft.styled";
 
-const HeaderLeft = ({ state: { handleMouseEvent, checkIsOpen } }) => {
+const HeaderLeft = ({ state }) => {
   return (
     <NavArea>
       <h1>Ordering</h1>
-      <Nav state={{ handleMouseEvent, checkIsOpen }} />
-      {/* TODO: submenu를 이 위치로 옮기기 */}
+      <Nav state={state} />
     </NavArea>
   );
 };
 
 HeaderLeft.propTypes = {
-  state: PropTypes.objectOf(PropTypes.func).isRequired,
+  state: PropTypes.objectOf(
+    PropTypes.oneOfType([PropTypes.func, PropTypes.bool])
+  ).isRequired,
 };
 
 export default HeaderLeft;

--- a/fe/src/Component/Header/HeaderLeft/Menu.jsx
+++ b/fe/src/Component/Header/HeaderLeft/Menu.jsx
@@ -22,7 +22,7 @@ const Menu = ({ isOpen }) => {
 };
 
 Menu.propTypes = {
-  isOpen: PropTypes.func.isRequired,
+  isOpen: PropTypes.bool.isRequired,
 };
 
 SubMenu.propTypes = {

--- a/fe/src/Component/Header/HeaderLeft/Nav.jsx
+++ b/fe/src/Component/Header/HeaderLeft/Nav.jsx
@@ -2,16 +2,18 @@ import PropTypes from "prop-types";
 import Menu from "./Menu";
 import StyledNav from "./Nav.styled";
 
-const Nav = ({ state: { handleMouseEvent, checkIsOpen } }) => {
+const Nav = ({ state: { handleMouseEvent, isSubMenuOpen } }) => {
   return (
     <StyledNav onMouseEnter={handleMouseEvent} onMouseLeave={handleMouseEvent}>
-      <Menu isOpen={checkIsOpen()} />
+      <Menu isOpen={isSubMenuOpen} />
     </StyledNav>
   );
 };
 
 Nav.propTypes = {
-  state: PropTypes.objectOf(PropTypes.func).isRequired,
+  state: PropTypes.objectOf(
+    PropTypes.oneOfType([PropTypes.func, PropTypes.bool])
+  ).isRequired,
 };
 
 export default Nav;


### PR DESCRIPTION
## 세부 내용

- Header에서 isOpen을 넘겨줄때 함수로 넘겨줄 필요가 없어서 `boolean`으로 변경했습니다
  - 넘겨줄때 그냥 isOpen을 바로 넘겨도 될 지 모르겠어서 일단 새로 `isSubMenuOpen`을 선언해서 넘겼습니다
  
- 하위 컴포넌트로 props를 넘겨줄때 매번 destructuring을 하면, 메모리상에서 새로운 객체로 생성된다는 글을 읽고(https://cocoder16.tistory.com/36) 마지막에 사용하는 쪽에서만(`Nav`컴포넌트) destructuring하는 것으로 변경하였습니다.